### PR TITLE
submission information

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <h2>Important Dates</h2>
 
     <ul>
-      <li>Submission of extended abstracts: <b>22nd April 2026</b> (AoE)</li>
+      <li>Submission, in all three categories: <b>22nd April 2026</b> (AoE), at <a href="https://submissions.floc26.org/wpte/">https://submissions.floc26.org/wpte/</a></li>
       <li>Notification of acceptance: 25th May 2026</li>
       <li>Early <a href="https://www.floc26.org/registration">registration</a> for the workshop: 1st June 2026</li>
       <li>Workshop: 19th July 2026</li>


### PR DESCRIPTION
The switch from "of extended abstracts" to "in all three categories" is the important bit. But I thought linking to the submission site from the page itself (rather than having to look it up in the linked CFP) would also be a good idea.